### PR TITLE
fix macOS platform detection by changing comparison from macOS to Darwin

### DIFF
--- a/lol_language_changer.py
+++ b/lol_language_changer.py
@@ -269,7 +269,7 @@ def on_click_change():
     elif os_type == "Linux":
         if WINEPREFIX is not None:
             success = start_lol_linux()
-    elif os_type == "macOS":
+    elif os_type == "Darwin":
         if WINEPREFIX is not None:
             success = start_lol_mac_wine()
         else:


### PR DESCRIPTION
on macOS return value of platform.system() will be "Darwin" 

from https://docs.python.org/3/library/platform.html

platform.system()
Returns the system/OS name, such as 'Linux', 'Darwin', 'Java', 'Windows'. An empty string is returned if the value cannot be determined.